### PR TITLE
Add frame modifier to scroll view content

### DIFF
--- a/Sources/ScrollViewIfNeeded/ScrollViewIfNeeded.swift
+++ b/Sources/ScrollViewIfNeeded/ScrollViewIfNeeded.swift
@@ -77,6 +77,8 @@ public struct ScrollViewIfNeeded<Content>: View where Content : View {
                             )
                         }
                     )
+                    .frame(minWidth: geometryReader.size.width, minHeight: geometryReader.size.height)
+
             }
             .onPreferenceChange(ViewSizeKey.self) {
                 fitsVertically = $0.height <= geometryReader.size.height


### PR DESCRIPTION
Add min width and height to mimic the layout behavior of when the content is not wrapped in a ScrollView.

1. Centers the content when it is smaller than the scroll view container. This makes the ScrollView more transparent when it's not scrollable.
2. Fixes a bug where the content would not become scrollable when the content size would increase due to a change in dynamic text size. (Cmd-Option-+ in the Simulator)

Not sure about number 2. I've seen an instance where the old behavior persisted.